### PR TITLE
Am/interface usage

### DIFF
--- a/examples/definitions.rb
+++ b/examples/definitions.rb
@@ -23,9 +23,6 @@ class GraphQL::UserObject < GraphQL::Object
 
   implements :named, :aged
 
-  field :first_name, :string, null: false, desc: "The user's first name"
-  field :last_name, :string, null: false, desc: "The user's last name"
-  field :age, :integer, null: false, desc: "The user's age"
   field :birthdate, :date, null: false, desc: "The user's birthdate"
 end
 

--- a/examples/definitions.rb
+++ b/examples/definitions.rb
@@ -15,13 +15,14 @@ end
 class GraphQL::AgedInterface < GraphQL::Interface
   desc 'Any entity that has an age field'
 
-  field :age, :integer, null: false
+  field :age, :integer, null: true
 end
 
 class GraphQL::UserObject < GraphQL::Object
   desc 'Simple information about an user'
 
   implements :named, :aged
+  overwrite_field :age, null: false, desc: "The user's age"
 
   field :birthdate, :date, null: false, desc: "The user's birthdate"
 end

--- a/lib/rails/graphql/field.rb
+++ b/lib/rails/graphql/field.rb
@@ -226,6 +226,21 @@ module Rails # :nodoc:
         "#<GraphQL::Field @owner=\"#{owner.name}\" #{name}#{args}:#{extra}#{dirs}>"
       end
 
+      # Update the null value if possible
+      def set_null(value)
+        return if @null == value || value.nil?
+
+        raise DefinitionError, <<~MSG.squish unless !!value == value
+          null value should be either true or false.
+        MSG
+
+        raise DefinitionError, <<~MSG.squish unless @null
+          Cannot overwrite a null field.
+        MSG
+
+        @null = value
+      end
+
       private
 
         def match_arguments?(other)

--- a/lib/rails/graphql/field.rb
+++ b/lib/rails/graphql/field.rb
@@ -226,19 +226,9 @@ module Rails # :nodoc:
         "#<GraphQL::Field @owner=\"#{owner.name}\" #{name}#{args}:#{extra}#{dirs}>"
       end
 
-      # Update the null value if possible
-      def set_null(value)
-        return if @null == value || value.nil?
-
-        raise DefinitionError, <<~MSG.squish unless !!value == value
-          null value should be either true or false.
-        MSG
-
-        raise DefinitionError, <<~MSG.squish unless @null
-          Cannot overwrite a null field.
-        MSG
-
-        @null = value
+      # Update the null value
+      def required!
+        @null = false
       end
 
       private

--- a/lib/rails/graphql/helpers.rb
+++ b/lib/rails/graphql/helpers.rb
@@ -13,7 +13,6 @@ module Rails # :nodoc:
       autoload :WithDirectives
       autoload :WithFields
       autoload :WithNamespace
-
     end
   end
 end

--- a/lib/rails/graphql/helpers/with_fields.rb
+++ b/lib/rails/graphql/helpers/with_fields.rb
@@ -54,18 +54,14 @@ module Rails # :nodoc:
         end
 
         # Overwrite the :null and :desc attributes of field
-        def overwrite_field(name, *args, **xargs)
-          field = fields[name]
-          raise ArgumentError, <<~MSG.squish unless field
+        def overwrite_field(name, null: true, desc: nil)
+          raise ArgumentError, <<~MSG.squish unless fields.key?(name)
             The #{name.inspect} field was not defined.
           MSG
 
-          raise ArgumentError, <<~MSG.squish if args.any? || xargs.keys.sort != [:desc, :null]
-            Can only change null(from true to false) and description on field overwrite.
-          MSG
-
-          field.set_null(xargs[:null])
-          field.instance_variable_set(:@desc, xargs[:desc]&.squish)
+          field = fields[name]
+          field.required! unless null
+          field.instance_variable_set(:@desc, desc.squish) if desc.present?
         end
 
         private

--- a/lib/rails/graphql/helpers/with_fields.rb
+++ b/lib/rails/graphql/helpers/with_fields.rb
@@ -53,6 +53,21 @@ module Rails # :nodoc:
           raise e.class, e.message + "\n  Defined at: #{caller(2)[0]}"
         end
 
+        # Overwrite the :null and :desc attributes of field
+        def overwrite_field(name, *args, **xargs)
+          field = fields[name]
+          raise ArgumentError, <<~MSG.squish unless field
+            The #{name.inspect} field was not defined.
+          MSG
+
+          raise ArgumentError, <<~MSG.squish if args.any? || xargs.keys.sort != [:desc, :null]
+            Can only change null(from true to false) and description on field overwrite.
+          MSG
+
+          field.set_null(xargs[:null])
+          field.instance_variable_set(:@desc, xargs[:desc]&.squish)
+        end
+
         private
 
           def field_builder

--- a/lib/rails/graphql/type/interface.rb
+++ b/lib/rails/graphql/type/interface.rb
@@ -46,14 +46,14 @@ module Rails # :nodoc:
 
             missing_keys = fields.keys - object.fields.keys
             raise ArgumentError, <<~MSG.squish if missing_keys.present?
-              The "#{object.gql_name}" doesn't correctly implements "#{gql_name}", because
+              The "#{object.gql_name}" doesn't correctly implement "#{gql_name}", because
               the #{missing_keys.map { |key| fields[key].gql_name.inspect }.to_sentence}
               #{'field'.pluralize(missing_keys.size)} are missing.
             MSG
 
             fields.each do |key, item|
               raise ArgumentError, <<~MSG.squish unless object.fields[key] == item
-                The "#{object.gql_name}" doesn't correctly implements "#{gql_name}",
+                The "#{object.gql_name}" doesn't correctly implement "#{gql_name}",
                 because the "#{item.gql_name}" field has different definition.
               MSG
             end

--- a/lib/rails/graphql/type/interface.rb
+++ b/lib/rails/graphql/type/interface.rb
@@ -40,25 +40,9 @@ module Rails # :nodoc:
           end
 
           # Check if the given object is properly implementing this interface
-          def validate!(object = nil)
-            super if defined? super
-            return if object.nil?
-
-            missing_keys = fields.keys - object.fields.keys
-            raise ArgumentError, <<~MSG.squish if missing_keys.present?
-              The "#{object.gql_name}" doesn't correctly implement "#{gql_name}", because
-              the #{missing_keys.map { |key| fields[key].gql_name.inspect }.to_sentence}
-              #{'field'.pluralize(missing_keys.size)} are missing.
-            MSG
-
-            fields.each do |key, item|
-              raise ArgumentError, <<~MSG.squish unless object.fields[key] == item
-                The "#{object.gql_name}" doesn't correctly implement "#{gql_name}",
-                because the "#{item.gql_name}" field has different definition.
-              MSG
-            end
-
-            nil # No exception already means valid
+          def validate(*)
+            # Don't validate interfaces since the fields are copied and
+            # the interface might have broken field types
           end
         end
       end

--- a/lib/rails/graphql/type/object.rb
+++ b/lib/rails/graphql/type/object.rb
@@ -90,6 +90,7 @@ module Rails # :nodoc:
               One or more items are not valid interfaces.
             MSG
 
+            merge_fields(others)
             interfaces.merge(others)
           end
 
@@ -106,6 +107,16 @@ module Rails # :nodoc:
             super if defined? super
             all_interfaces.all? { |item| item.validate!(self) }
             nil # No exception already means valid
+          end
+
+          def merge_fields(others)
+            copy_fields = -> interface {
+              new_fields = interface.fields.transform_values do |item|
+                item.dup.tap { |x| x.instance_variable_set(:@owner, self) }
+              end
+              fields.merge!(new_fields)
+            }
+            others.each &copy_fields
           end
 
           protected


### PR DESCRIPTION
We copy the interface fields to the object
We ensure that only :null and :desc fields are updated on `overwrite_field` call