### PR TITLE
Provide local gql_name override

### DIFF
--- a/lib/rails/graphql/field.rb
+++ b/lib/rails/graphql/field.rb
@@ -116,6 +116,7 @@ module Rails
         @null     = full ? false : xargs.fetch(:null, true)
         @array    = full ? true  : xargs.fetch(:array, false)
         @nullable = full ? false : xargs.fetch(:nullable, true)
+        @gql_name = xargs.fetch(:gql_name, @gql_name)
 
         self.description = xargs[:desc] || xargs[:description]
         @enabled = xargs.fetch(:enabled, !xargs.fetch(:disabled, false))


### PR DESCRIPTION
If `:gql_name` is provided it will override `@gql_name`. If not it will use default calculated `@gql_name` from `normalize_name`.

in my source i can now do:

```
    step(:object) do
      field(:download_url, gql_name: 'downloadUrl')
      field(:update_url, gql_name: 'updateUrl')
    end
```

Let me know what you think