### PR TITLE
fix controller name mentioned in the guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,7 +103,7 @@ The only thing added for this example is the skip of the authenticity token sinc
 we will be using a `POST` method.
 
 ```ruby
-# app/controllers/google_controller.rb
+# app/controllers/graphql_controller.rb
 class GraphQLController < ApplicationController
   include GraphQL::Controller
 


### PR DESCRIPTION
Hello, I noticed that typo controller name in  Using a Controller section of  [getting started page](https://rails-graphql.dev/getting-started).

Could you please review it?
