### PR TITLE
Fix non-null argument validation

### DIFF
--- a/lib/rails/graphql/request/steps/organizable.rb
+++ b/lib/rails/graphql/request/steps/organizable.rb
@@ -118,11 +118,9 @@ module Rails
           # Helper parser for arguments that also collect necessary variables
           # Default values forces this method to run even without nodes
           def parse_arguments(nodes)
-            return @arguments = EMPTY_HASH if nodes.blank?
-
-            args = nodes.each.with_object({}) do |(name, value, var_name), hash|
+            args = nodes&.each&.with_object({}) do |(name, value, var_name), hash|
               hash[name.to_s] = var_name.nil? ? value : var_name
-            end
+            end || {}
 
             args = collect_arguments(self, args)
             @arguments = request.build(Request::Arguments, args).freeze


### PR DESCRIPTION
### Problem

When defining a schema with a required (non-nullable) argument, the current implementation does not validate the presence of that argument when it's missing in a query. Instead of returning an error as expected, the query executes with the argument set to `nil`, leading to potentially unintended behavior.

#### Example Schema
```ruby
query_fields do
  field(:welcome) do
    argument(:name, null: false)
  end
end

def welcome(name:)
  "Hello #{name}!"
end
```

(as graphql schema :
```graphql
schema {
  query: {
    welcome(name: String!): String!
  }
}
```
)


#### Current Behavior
Query:
```graphql
query {
  welcome
}
```

Response:
```json
{
  "data": {
    "welcome": "Hello !"
  }
}
```

Expected Behavior:
The server should return an error indicating that the `name` argument cannot be null.

#### Root Cause
The issue lies in the `Rails::GraphQL::Request::Organizable#parse_arguments` method, which returns an empty hash (`EMPTY_HASH`) if `nodes` is blank. This bypasses the invocation of the `::Organizable#collect_arguments` method, which contains the logic to check for non-nullable arguments.

Relevant snippet from `collect_arguments`:
```ruby
# Checks for any required argument that was not provided
source.each_value do |argument|
  next if result.key?(argument.name) || argument.null?
  errors << +"the \"#{argument.gql_name}\" argument can not be null"
end
```

### Proposed Solution
Modify the `#parse_arguments` method to avoid returning prematurely when `nodes` is blank. Instead, ensure `collect_arguments` is always called, even if `nodes` is nil. This is achieved by updating the code to handle the potential nullity of `nodes` using safe navigation (`&.`).

### Why This Fix is Important
This bug is critical because it allows a query to bypass required argument checks, potentially leading to:
- Unexpected application behavior.
- Security vulnerabilities if developers do not manually validate null arguments.

### Implementation
- Ensure `#collect_arguments` is invoked regardless of whether `nodes` is blank.
- Adapt the `nodes.each.with_object({})` logic with safe chaining (`&.`) to gracefully handle cases where `nodes` is nil.

### Testing (TODO)
- Add test cases to ensure that queries missing non-nullable arguments return the correct error.
- Validate that no regressions occur with nullable arguments or valid queries.

---

This fix addresses a critical validation bug in argument handling, improving both developer experience and application security.

---

Let me know if further details are needed!