### PR TITLE
Ensure Rails 8.2 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,67 +7,70 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (7.2.1.2)
-      actionpack (= 7.2.1.2)
-      activesupport (= 7.2.1.2)
+    actioncable (7.2.3)
+      actionpack (= 7.2.3)
+      activesupport (= 7.2.3)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
       zeitwerk (~> 2.6)
-    actionmailbox (7.2.1.2)
-      actionpack (= 7.2.1.2)
-      activejob (= 7.2.1.2)
-      activerecord (= 7.2.1.2)
-      activestorage (= 7.2.1.2)
-      activesupport (= 7.2.1.2)
+    actionmailbox (7.2.3)
+      actionpack (= 7.2.3)
+      activejob (= 7.2.3)
+      activerecord (= 7.2.3)
+      activestorage (= 7.2.3)
+      activesupport (= 7.2.3)
       mail (>= 2.8.0)
-    actionmailer (7.2.1.2)
-      actionpack (= 7.2.1.2)
-      actionview (= 7.2.1.2)
-      activejob (= 7.2.1.2)
-      activesupport (= 7.2.1.2)
+    actionmailer (7.2.3)
+      actionpack (= 7.2.3)
+      actionview (= 7.2.3)
+      activejob (= 7.2.3)
+      activesupport (= 7.2.3)
       mail (>= 2.8.0)
       rails-dom-testing (~> 2.2)
-    actionpack (7.2.1.2)
-      actionview (= 7.2.1.2)
-      activesupport (= 7.2.1.2)
+    actionpack (7.2.3)
+      actionview (= 7.2.3)
+      activesupport (= 7.2.3)
+      cgi
       nokogiri (>= 1.8.5)
       racc
-      rack (>= 2.2.4, < 3.2)
+      rack (>= 2.2.4, < 3.3)
       rack-session (>= 1.0.1)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actiontext (7.2.1.2)
-      actionpack (= 7.2.1.2)
-      activerecord (= 7.2.1.2)
-      activestorage (= 7.2.1.2)
-      activesupport (= 7.2.1.2)
+    actiontext (7.2.3)
+      actionpack (= 7.2.3)
+      activerecord (= 7.2.3)
+      activestorage (= 7.2.3)
+      activesupport (= 7.2.3)
       globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (7.2.1.2)
-      activesupport (= 7.2.1.2)
+    actionview (7.2.3)
+      activesupport (= 7.2.3)
       builder (~> 3.1)
+      cgi
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activejob (7.2.1.2)
-      activesupport (= 7.2.1.2)
+    activejob (7.2.3)
+      activesupport (= 7.2.3)
       globalid (>= 0.3.6)
-    activemodel (7.2.1.2)
-      activesupport (= 7.2.1.2)
-    activerecord (7.2.1.2)
-      activemodel (= 7.2.1.2)
-      activesupport (= 7.2.1.2)
+    activemodel (7.2.3)
+      activesupport (= 7.2.3)
+    activerecord (7.2.3)
+      activemodel (= 7.2.3)
+      activesupport (= 7.2.3)
       timeout (>= 0.4.0)
-    activestorage (7.2.1.2)
-      actionpack (= 7.2.1.2)
-      activejob (= 7.2.1.2)
-      activerecord (= 7.2.1.2)
-      activesupport (= 7.2.1.2)
+    activestorage (7.2.3)
+      actionpack (= 7.2.3)
+      activejob (= 7.2.3)
+      activerecord (= 7.2.3)
+      activesupport (= 7.2.3)
       marcel (~> 1.0)
-    activesupport (7.2.1.2)
+    activesupport (7.2.3)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
@@ -78,143 +81,168 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     ansi (1.5.0)
-    base64 (0.2.0)
+    base64 (0.3.0)
+    benchmark (0.5.0)
     benchmark-ips (2.8.4)
-    bigdecimal (3.1.8)
-    bootsnap (1.11.1)
+    bigdecimal (4.0.1)
+    bootsnap (1.23.0)
       msgpack (~> 1.2)
-    builder (3.2.4)
-    byebug (11.1.3)
+    builder (3.3.0)
+    byebug (13.0.0)
+      reline (>= 0.6.0)
+    cgi (0.5.1)
     coderay (1.1.3)
-    concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     crass (1.0.6)
-    date (3.3.4)
-    docile (1.4.0)
-    drb (2.2.1)
-    erubi (1.13.0)
+    date (3.5.1)
+    docile (1.4.1)
+    drb (2.2.3)
+    erubi (1.13.1)
     flamegraph (0.9.5)
-    globalid (1.2.1)
+    globalid (1.3.0)
       activesupport (>= 6.1)
-    i18n (1.14.6)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    io-console (0.7.2)
-    irb (1.14.1)
+    io-console (0.8.2)
+    irb (1.17.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    logger (1.6.1)
-    loofah (2.23.1)
+    logger (1.7.0)
+    loofah (2.25.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.8.1)
+    mail (2.9.0)
+      logger
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.4)
-    method_source (1.0.0)
+    marcel (1.1.0)
+    method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.7)
+    mini_portile2 (2.8.9)
     minitest (5.14.4)
     minitest-reporters (1.4.3)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    msgpack (1.5.1)
-    mysql2 (0.5.4)
-    net-imap (0.5.0)
+    msgpack (1.8.0)
+    mutex_m (0.3.0)
+    mysql2 (0.5.7)
+      bigdecimal
+    net-imap (0.6.3)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
-    nio4r (2.7.4)
-    nokogiri (1.16.7)
+    nio4r (2.7.5)
+    nokogiri (1.19.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    pg (1.3.5)
-    pry (0.14.2)
+    nokogiri (1.19.1-arm64-darwin)
+      racc (~> 1.4)
+    ostruct (0.6.3)
+    pg (1.6.3)
+    pg (1.6.3-arm64-darwin)
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
-    psych (4.0.4)
+      reline (>= 0.6.0)
+    pry-byebug (3.12.0)
+      byebug (~> 13.0)
+      pry (>= 0.13, < 0.17)
+    psych (5.3.1)
+      date
       stringio
     racc (1.8.1)
-    rack (3.1.8)
-    rack-session (2.0.0)
+    rack (3.2.5)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
       rack (>= 3.0.0)
-    rack-test (2.1.0)
+    rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (2.1.0)
+    rackup (2.3.1)
       rack (>= 3)
-      webrick (~> 1.8)
-    rails (7.2.1.2)
-      actioncable (= 7.2.1.2)
-      actionmailbox (= 7.2.1.2)
-      actionmailer (= 7.2.1.2)
-      actionpack (= 7.2.1.2)
-      actiontext (= 7.2.1.2)
-      actionview (= 7.2.1.2)
-      activejob (= 7.2.1.2)
-      activemodel (= 7.2.1.2)
-      activerecord (= 7.2.1.2)
-      activestorage (= 7.2.1.2)
-      activesupport (= 7.2.1.2)
+    rails (7.2.3)
+      actioncable (= 7.2.3)
+      actionmailbox (= 7.2.3)
+      actionmailer (= 7.2.3)
+      actionpack (= 7.2.3)
+      actiontext (= 7.2.3)
+      actionview (= 7.2.3)
+      activejob (= 7.2.3)
+      activemodel (= 7.2.3)
+      activerecord (= 7.2.3)
+      activestorage (= 7.2.3)
+      activesupport (= 7.2.3)
       bundler (>= 1.15.0)
-      railties (= 7.2.1.2)
-    rails-dom-testing (2.2.0)
+      railties (= 7.2.3)
+    rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.0)
+    rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
-      nokogiri (~> 1.14)
-    railties (7.2.1.2)
-      actionpack (= 7.2.1.2)
-      activesupport (= 7.2.1.2)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (7.2.3)
+      actionpack (= 7.2.3)
+      activesupport (= 7.2.3)
+      cgi
       irb (~> 1.13)
       rackup (>= 1.0.0)
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
       zeitwerk (~> 2.6)
-    rake (13.0.6)
+    rake (13.3.1)
     rake-compiler (1.1.9)
       rake
     rake-compiler-dock (1.0.1)
-    rdoc (6.4.0)
+    rdoc (6.4.1.1)
       psych (>= 4.0.0)
-    reline (0.5.10)
+    reline (0.6.3)
       io-console (~> 0.5)
-    ruby-prof (1.4.3)
-    ruby-progressbar (1.11.0)
-    securerandom (0.3.1)
-    simplecov (0.21.2)
+    ruby-prof (2.0.1)
+      base64
+      ostruct
+    ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
+    simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    sqlite3 (1.4.2)
-    stackprof (0.2.19)
-    stringio (3.0.2)
-    thor (1.3.2)
-    timeout (0.4.1)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
+    stackprof (0.2.28)
+    stringio (3.2.0)
+    thor (1.5.0)
+    timeout (0.6.0)
+    tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    useragent (0.16.10)
-    webrick (1.8.2)
-    websocket-driver (0.7.6)
+    useragent (0.16.11)
+    websocket-driver (0.8.0)
+      base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.18)
+    zeitwerk (2.7.4)
 
 PLATFORMS
+  arm64-darwin-25
   ruby
 
 DEPENDENCIES
@@ -223,6 +251,7 @@ DEPENDENCIES
   flamegraph
   minitest (~> 5.14.0)
   minitest-reporters (~> 1.4.2)
+  mutex_m
   mysql2 (~> 0.5)
   pg (~> 1.3)
   pry-byebug
@@ -236,5 +265,100 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
   stackprof
 
+CHECKSUMS
+  actioncable (7.2.3) sha256=e15d17b245f1dfe7cafdda4a0c6f7ba8ebaab1af33884415e09cfef4e93ad4f9
+  actionmailbox (7.2.3) sha256=16bbf0a7c330f2d08d52d5e3c1b03813a8ef60bfb0a48e89c0bf92b069cb4d5e
+  actionmailer (7.2.3) sha256=68d646b852a6d2b25d8834fc796c3dc10f76a4c7fd77b3251c3f4dd832ec8ab8
+  actionpack (7.2.3) sha256=2a14e4c64695777041ea7aaf498462284cadd561f009654393daf9b2de7207cf
+  actiontext (7.2.3) sha256=a6ffd9efb7b7b4e26029e5c88e8a2ea9aae8d6cefdfed960be139772f1a94037
+  actionview (7.2.3) sha256=1f427d7a41b43804d7250911535740451b9c32b6416239d87e6dab9d5948ecb2
+  activejob (7.2.3) sha256=e44964472de267b69e93752f088193c8ad2e56d2ef451d059dd7a53761e5ffb0
+  activemodel (7.2.3) sha256=bbaf66aeb93212e98ebf6ab900f8290f9a831645f0b235427f5acf0e074739db
+  activerecord (7.2.3) sha256=6facb7478ceb5f6baa9f0647daa50b4a3a43934997900f0011e6c667ff41a0d7
+  activestorage (7.2.3) sha256=4c1422bbfaa60c89e7b43cc38ade7bd3b8dc81024c48a21c1ac56814cf34ca2f
+  activesupport (7.2.3) sha256=5675c9770dac93e371412684249f9dc3c8cec104efd0624362a520ae685c7b10
+  ansi (1.5.0) sha256=5408253274e33d9d27d4a98c46d2998266fd51cba58a7eb9d08f50e57ed23592
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
+  benchmark-ips (2.8.4) sha256=eb36669c7e66809be3b6be9ede9012769adcff4ba7672e91eec344f4e8d79a8d
+  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
+  builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
+  cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
+  coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
+  flamegraph (0.9.5) sha256=a683020637ffa0e14a72640fa41babf14d926bfeaed87e31907cfd06ab2de8dc
+  globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  loofah (2.25.0) sha256=df5ed7ac3bac6a4ec802df3877ee5cc86d027299f8952e6243b3dac446b060e6
+  mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
+  marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
+  method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
+  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
+  mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
+  minitest (5.14.4) sha256=f4716634d71b3ffb627cd63ba4f6f0f77c7a3f17353b1bdf52c8a7f2e0e4e7a7
+  minitest-reporters (1.4.3) sha256=26f72e4a197429ac0a745c27f046c8f8f0547666b40c98191a0ca99f8546495e
+  msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
+  mysql2 (0.5.7) sha256=ba09ede515a0ae8a7192040a1b778c0fb0f025fa5877e9be895cd325fa5e9d7b
+  net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
+  net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
+  net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
+  net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
+  nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
+  nokogiri (1.19.1) sha256=598b327f36df0b172abd57b68b18979a6e14219353bca87180c31a51a00d5ad3
+  nokogiri (1.19.1-arm64-darwin) sha256=dfe2d337e6700eac47290407c289d56bcf85805d128c1b5a6434ddb79731cb9e
+  ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
+  pg (1.6.3) sha256=1388d0563e13d2758c1089e35e973a3249e955c659592d10e5b77c468f628a99
+  pg (1.6.3-arm64-darwin) sha256=7240330b572e6355d7c75a7de535edb5dfcbd6295d9c7777df4d9dddfb8c0e5f
+  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  pry (0.16.0) sha256=d76c69065698ed1f85e717bd33d7942c38a50868f6b0673c636192b3d1b6054e
+  pry-byebug (3.12.0) sha256=594e094ae8a8390a7ad4c7b36ae36e13304ed02664c67417d108dc5f7213d1b7
+  psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.5) sha256=4cbd0974c0b79f7a139b4812004a62e4c60b145cba76422e288ee670601ed6d3
+  rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
+  rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
+  rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
+  rails (7.2.3) sha256=9a9812eb131189676e64665f6883fc9c4051f412cc87ef9e3fa242a09c609bff
+  rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
+  rails-graphql (1.0.6)
+  rails-html-sanitizer (1.6.2) sha256=35fce2ca8242da8775c83b6ba9c1bcaad6751d9eb73c1abaa8403475ab89a560
+  railties (7.2.3) sha256=6eb010a6bfe6f223e783f739ddfcbdb5b88b1f3a87f7739f0a0685e466250422
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  rake-compiler (1.1.9) sha256=51b5c95a1ff25cabaaf92e674a2bed847ab53d66302fc8843830df46ab1f51f5
+  rake-compiler-dock (1.0.1) sha256=3f041aa489ce518230f3e43c956ca03e6959e3b95e114defcf8d0a12cf76b29a
+  rdoc (6.4.1.1) sha256=79d740d4b5a04cc8c9d65c4ecfb966ffec51471b086ca75df9d80c5c32104131
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  ruby-prof (2.0.1) sha256=4c39dd3c81515d8fb04a90288a842b5654a358cbf5d7db2c908523329dbf588c
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+  sqlite3 (1.7.3) sha256=fa77f63c709548f46d4e9b6bb45cda52aa3881aa12cc85991132758e8968701c
+  stackprof (0.2.28) sha256=4ec2ace02f386012b40ca20ef80c030ad711831f59511da12e83b34efb0f9a04
+  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
+  timeout (0.6.0) sha256=6d722ad619f96ee383a0c557ec6eb8c4ecb08af3af62098a0be5057bf00de1af
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
+  websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
+  zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
+
 BUNDLED WITH
-   2.3.26
+  4.0.6

--- a/lib/rails/graphql.rb
+++ b/lib/rails/graphql.rb
@@ -10,6 +10,7 @@ require 'active_support/core_ext/module/attribute_accessors_per_thread'
 require 'active_support/core_ext/string/strip'
 require 'active_support/core_ext/enumerable'
 
+require 'rails/graphql/configurable'
 require 'rails/graphql/version'
 require 'rails/graphql/uri'
 
@@ -47,8 +48,7 @@ module Rails
   #   differently.
   module GraphQL
     extend ActiveSupport::Autoload
-
-    include ActiveSupport::Configurable
+    extend Configurable
 
     # Stores the version of the GraphQL spec used for this implementation
     SPEC_VERSION = ::GQLParser::VERSION

--- a/lib/rails/graphql/configurable.rb
+++ b/lib/rails/graphql/configurable.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/object/deep_dup'
+require 'active_support/ordered_options'
+
+module Rails
+  module GraphQL
+    module Configurable
+      def config
+        @config ||= begin
+          parent = respond_to?(:superclass) ? superclass : nil
+          parent.respond_to?(:config) ? parent.config.deep_dup : ActiveSupport::InheritableOptions.new
+        end
+      end
+
+      def config=(value)
+        @config = value
+      end
+
+      def configure
+        yield(config)
+      end
+    end
+  end
+end

--- a/lib/rails/graphql/global_id.rb
+++ b/lib/rails/graphql/global_id.rb
@@ -21,6 +21,11 @@ module Rails
 
         class << self
           delegate :serialize?, :serialize, :deserialize, to: :instance
+
+          # The class of the object that will be serialized.
+          def klass
+            GlobalID
+          end
         end
 
         # Determines if an argument should be serialized by this serializer.
@@ -37,12 +42,6 @@ module Rails
         def deserialize(argument)
           GlobalID.find argument[GlobalID::SERIALIZER_KEY]
         end
-
-        private
-          # The class of the object that will be serialized.
-          def klass
-            GlobalID
-          end
       end
 
       class << self

--- a/lib/rails/graphql/schema.rb
+++ b/lib/rails/graphql/schema.rb
@@ -21,9 +21,9 @@ module Rails
       extend Helpers::WithDirectives
       extend Helpers::WithGlobalID
       extend Helpers::Registerable
+      extend GraphQL::Configurable
       extend GraphQL::Introspection
 
-      include ActiveSupport::Configurable
       include ActiveSupport::Rescuable
       include Helpers::Instantiable
 
@@ -308,6 +308,7 @@ module Rails
             super if defined? super
 
             # The only way to actually get the namespace into the cache prefix
+            subclass.config = config.deep_dup
             subclass.config.define_singleton_method(:cache_prefix) do
               self[:cache_prefix] ||= "#{GraphQL.config.cache_prefix}#{subclass.namespace}/"
             end

--- a/rails-graphql.gemspec
+++ b/rails-graphql.gemspec
@@ -46,4 +46,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pg', '~> 1.3'
   s.add_development_dependency 'mysql2', '~> 0.5'
   s.add_development_dependency 'sqlite3', '~> 1.4'
+
+  s.add_development_dependency 'mutex_m'
 end

--- a/test/graphql/global_id_serializer_test.rb
+++ b/test/graphql/global_id_serializer_test.rb
@@ -1,0 +1,10 @@
+require 'config'
+
+class GraphQL_GlobalIDTest < GraphQL::TestCase
+  DESCRIBED_CLASS = unmapped_class(Rails::GraphQL::GlobalID::Serializer)
+
+  def test_klass
+    assert(DESCRIBED_CLASS.respond_to?(:klass))
+    assert_equal(Rails::GraphQL::GlobalID, DESCRIBED_CLASS.klass)
+  end
+end


### PR DESCRIPTION
Replaces `ActiveSupport::Configurable` with a `Configurable` module that emulates the same functionality.